### PR TITLE
fix: do not indent single text children tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,29 +50,21 @@ Will return
 <!DOCTYPE html>
 <html>
   <head>
-    <title>
-      Example Website
-    </title>
+    <title>Example Website</title>
     <meta content="This is an example website build with tagic" name="description" />
   </head>
   <body>
     <header id="header">
-      <h1>
-        Awesome
-      </h1>
+      <h1>Awesome</h1>
     </header>
     <main>
       <p>
         Some text
-        <span>
-          with tags
-        </span>
+        <span>with tags</span>
         in between
       </p>
     </main>
-    <footer hidden>
-
-    </footer>
+    <footer hidden></footer>
   </body>
 </html>
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tagic"
-version = "1.4.0"
+version = "1.5.0"
 description = "Build html / xhtml with a nice syntax."
 authors = ["Tammo Ippen <tammo.ippen@posteo.de>"]
 readme = "README.md"

--- a/src/tagic/base.py
+++ b/src/tagic/base.py
@@ -18,10 +18,10 @@ Elements = Sequence[Element]
 
 class DOMConfig:
     # Specify the indent on rendering for every level.
-    INDENT = 2
+    INDENT: int = 2
     # Render the document xhtml1 complient. See
     # https://de.wikipedia.org/wiki/Extensible_Hypertext_Markup_Language
-    FULL_XHTML = False
+    FULL_XHTML: bool = False
 
 
 class _Meta(type):
@@ -74,6 +74,7 @@ class Node(metaclass=_Meta):
         # filter None children
         self.children = list(filter(_not_none, self.children))
         no_content = len(self.children) == 0
+        single_text = len(self.children) == 1 and isinstance(self.children[0], str)
 
         def indent_newline() -> None:
             nonlocal result
@@ -86,23 +87,29 @@ class Node(metaclass=_Meta):
             result += " />"
         else:
             result += ">"
-        indent_newline()
+        if not single_text:
+            indent_newline()
 
         result += self._render_content(new_indent)
 
         if not no_content:
-            result += f"{indent_str}</{self.tag_name}>"
+            if single_text:
+                result += f"</{self.tag_name}>"
+            else:
+                result += f"{indent_str}</{self.tag_name}>"
             indent_newline()
 
         return result
 
     def _render_content(self, indent: str | None) -> str:
+        # keep text of single text nodes without indent
+        if len(self.children) == 1 and isinstance(self.children[0], str):
+            return escape(self.children[0])
         result = ""
 
         for child in self.children:
-            if child is None:
-                continue
-            elif isinstance(child, str):
+            assert child is not None
+            if isinstance(child, str):
                 result += f"{indent or ''}{escape(child)}"
                 if indent is not None:
                     result += "\n"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -201,13 +201,9 @@ def test_indent():
             "    here we have some text\n"
             "    <br />\n"
             "    and some more text\n"
-            "    <span>\n"
-            "      This is special text\n"
-            "    </span>\n"
+            "    <span>This is special text</span>\n"
             "  </p>\n"
-            '  <p id="foo">\n'
-            "    some more text\n"
-            "  </p>\n"
+            '  <p id="foo">some more text</p>\n'
             "</div>\n"
         )
         assert expect == div[
@@ -228,9 +224,7 @@ def test_indent():
             "        here we have some text\n"
             "        <br />\n"
             "        and some more text\n"
-            "        <span>\n"
-            "            This is special text\n"
-            "        </span>\n"
+            "        <span>This is special text</span>\n"
             "    </p>\n"
             "</div>\n"
         )
@@ -251,31 +245,22 @@ def test_readme():
         "<!DOCTYPE html>\n"
         "<html>\n"
         "  <head>\n"
-        "    <title>\n"
-        "      Example Website\n"
-        "    </title>\n"
-        '    <meta content="This is an example website build with tagic" '
-        'name="description" />\n'
+        "    <title>Example Website</title>\n"
+        '    <meta content="This is an example website build with tagic" name="description" />\n'
         '    <meta charset="utf-8" />\n'
         "  </head>\n"
         "  <body>\n"
         '    <header id="header">\n'
-        "      <h1>\n"
-        "        Awesome\n"
-        "      </h1>\n"
+        "      <h1>Awesome</h1>\n"
         "    </header>\n"
         "    <main>\n"
         "      <p>\n"
         "        Some text \n"
-        "        <span>\n"
-        "          with tags\n"
-        "        </span>\n"
+        "        <span>with tags</span>\n"
         "        in between\n"
         "      </p>\n"
         "    </main>\n"
-        "    <footer hidden>\n"
-        "      \n"
-        "    </footer>\n"
+        "    <footer hidden></footer>\n"
         "  </body>\n"
         "</html>\n"
         ""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -246,7 +246,8 @@ def test_readme():
         "<html>\n"
         "  <head>\n"
         "    <title>Example Website</title>\n"
-        '    <meta content="This is an example website build with tagic" name="description" />\n'
+        '    <meta content="This is an example website build with tagic" '
+        'name="description" />\n'
         '    <meta charset="utf-8" />\n'
         "  </head>\n"
         "  <body>\n"

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -26,7 +26,7 @@ def test_some_content_child():
 
 
 def test_some_content_child_indent():
-    expect = '<root a="bar" b>\n  <child>\n    Baz\n  </child>\n  Fooo\n</root>\n'
+    expect = '<root a="bar" b>\n  <child>Baz</child>\n  Fooo\n</root>\n'
     child = XML("child")["Baz"]
     assert expect == (
         XML("root", attrs={"a": "bar", "b": True}, children=[child, "Fooo"])

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.11"


### PR DESCRIPTION
keeps the text as is without introducing whitespace around it